### PR TITLE
Fixed README.md concerning SBFspot

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ All _energy signals_ have an `On`/`Off` status with a _Reason_ to make it easy t
 
 This was forked from <https://github.com/codyc1515/homebridge-sma-inverter>. Differences:
 
-- Omitted the Eve-based history support which didn't quite work. Recommended alternative: [`sbfspot`](https://github.com/SBFspot/SBFspot) <sup>[`Docker` image](https://github.com/nakla/sbfspot)</sup> (which reads data locally, also via ModBus), and optionally upload let it upload your production data to <https://pvoutput.org> (easy to use UI)
+- Omitted the Eve-based history support which didn't quite work. Recommended alternative: [`sbfspot`](https://github.com/SBFspot/SBFspot) <sup>[`Docker` image](https://github.com/nakla/sbfspot)</sup> (which reads data locally, via SMAData2+), and optionally upload your production data to <https://pvoutput.org> (easy to use UI)
 - Omitted the "Total". Observe that in SMA's `SMA Energy` app.
 - Stopped exposing the inverter's information as light sensors (pseudo-live, today, total).
 - Removed inverter IP address configuration in favor of ~[zero config thanks to a link-local address](https://manuals.sma.de/SBSxx-10/en-US/1685190283.html)~ [zero config thanks to mDNS/DNS-SD discovering the inverter](https://manuals.sma.de/SBSxx-10/en-US/1687859467.html) instead.


### PR DESCRIPTION
SBFspot uses SMAData2+ communication protocol (like SunnyExplorer) instead of Modbus